### PR TITLE
User role improvements (#GI-53)

### DIFF
--- a/telegram/admin.py
+++ b/telegram/admin.py
@@ -1,8 +1,9 @@
 from django.contrib import admin
-from django.utils.translation import gettext_lazy as _
 from django.utils.text import capfirst
+from django.utils.translation import gettext_lazy as _
 
 from telegram.models import TelegramChat
+from user_roles.services import update_user_role
 
 
 @admin.register(TelegramChat)
@@ -15,3 +16,17 @@ class TelegramChatAdmin(admin.ModelAdmin):
     search_help_text = capfirst(
         _('telegram|admin|telegram_chat|search_help_text')
     )
+
+    def has_add_permission(self, request):
+        return False
+
+    def save_model(self, request, obj: TelegramChat, form, change):
+        if obj.id is not None:
+            telegram_chat = (
+                TelegramChat.objects
+                .select_related('role')
+                .get(id=obj.id)
+            )
+            if telegram_chat.role != obj.role:
+                update_user_role(user=telegram_chat, role=obj.role)
+        super().save_model(request, obj, form, change)

--- a/user_roles/services.py
+++ b/user_roles/services.py
@@ -10,7 +10,10 @@ __all__ = (
 
 
 @transaction.atomic
-def update_user_role(*, user: TelegramChat, role: UserRole):
+def update_user_role(*, user: TelegramChat, role: UserRole | None):
     user.role = role
     user.save()
-    ReportRoute.objects.filter(telegram_chat=user).exclude(unit__in=role.units.all()).delete()
+    report_routes = ReportRoute.objects.filter(telegram_chat=user)
+    if role is not None:
+        report_routes = report_routes.exclude(unit__in=role.units.all())
+    report_routes.delete()


### PR DESCRIPTION
* Handle telegram chat role modification. 
* Remove report routes which are not allowed to the role at telegram chat modification.
* Remove permission to add telegram chats.
* If `None` passed in `role` parameter, all routes related to user will be deleted.