### PR TITLE
Admin panel improvements (#GI-53)

### DIFF
--- a/reports/admin.py
+++ b/reports/admin.py
@@ -73,3 +73,4 @@ class ReportTypeAdmin(OnlyDebugAddChangeDeleteMixin, admin.ModelAdmin):
 class ReportRouteAdmin(admin.ModelAdmin):
     list_filter = ('telegram_chat', 'unit', 'report_type')
     list_select_related = ('telegram_chat', 'unit', 'report_type')
+    list_display = ('telegram_chat', 'unit', 'report_type')


### PR DESCRIPTION
* Add display of telegram chat, unit and report type in report routes list in admin.
* If `None` passed in `role` parameter, all routes related to user will be deleted.
* Handle telegram chat role modification. 
* Remove report routes which are not allowed to the role at telegram chat modification. 
* Remove permission to add telegram chats.